### PR TITLE
Fix project player outline broken in previous PR

### DIFF
--- a/index.css
+++ b/index.css
@@ -101,6 +101,8 @@ input[disabled] {
 
 .area {
   overflow: hidden;
+  margin: 0 -1px;
+  padding: 0 1px;
   -webkit-transition: height .2s;
   -o-transition: height .2s;
   -moz-transition: height .2s;


### PR DESCRIPTION
Before https://github.com/forkphorus/forkphorus/commit/5fbd33bc0beaad15b6f216ea846473e5a9ebd750:
![image](https://user-images.githubusercontent.com/90340988/209439217-41fc86c6-aceb-4d05-996c-782e408a7045.png)
After https://github.com/forkphorus/forkphorus/commit/5fbd33bc0beaad15b6f216ea846473e5a9ebd750:
![image](https://user-images.githubusercontent.com/90340988/209439211-0c65ce3d-6f90-4fe9-9059-3a6d7555e042.png)

This fixes it by readding some of the same CSS that was removed in that commit.

Sorry for not testing it properly