### PR TITLE
Redo error handling

### DIFF
--- a/phosphorus.dist.js
+++ b/phosphorus.dist.js
@@ -4706,6 +4706,14 @@ var P;
                 }
             }
             step() {
+                try {
+                    this._step();
+                }
+                catch (e) {
+                    this.onError(e);
+                }
+            }
+            _step() {
                 self = this.stage;
                 runtime = this;
                 VISUAL = false;
@@ -4756,7 +4764,7 @@ var P;
             }
             onError(e) {
                 clearInterval(this.interval);
-                this.handleError(e.error);
+                this.handleError(e);
             }
             handleError(e) {
                 console.error(e);

--- a/phosphorus.dist.js
+++ b/phosphorus.dist.js
@@ -4633,7 +4633,6 @@ var P;
                 this.isRunning = true;
                 if (this.interval)
                     return;
-                window.addEventListener('error', this.onError);
                 this.baseTime = Date.now();
                 this.interval = setInterval(this.step, 1000 / this.framerate);
                 if (audioContext)
@@ -4645,7 +4644,6 @@ var P;
                     this.baseNow = this.now();
                     clearInterval(this.interval);
                     this.interval = 0;
-                    window.removeEventListener('error', this.onError);
                     if (audioContext)
                         audioContext.suspend();
                     this.stage.pauseExtensions();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -815,9 +815,20 @@ namespace P.runtime {
     }
 
     /**
+     * Wrapper for _step with error handling.
+     */
+    step () {
+      try {
+        this._step();
+      } catch (e) {
+        this.onError(e);
+      }
+    }
+
+    /**
      * Advances one frame into the future.
      */
-    step() {
+    _step() {
       // Reset runtime variables
       self = this.stage;
       runtime = this;
@@ -879,13 +890,20 @@ namespace P.runtime {
       this.stage.draw();
     }
 
-    onError(e) {
+    /**
+     * Called when an internal error occurs
+     * @param e Error object
+     */
+    onError(e: unknown) {
       clearInterval(this.interval);
-      this.handleError(e.error);
+      this.handleError(e);
     }
 
-    handleError(e) {
-      // Default error handler
+    /**
+     * Overridden to cusutomize error handling.
+     * @param e The error object
+     */
+    handleError(e: unknown) {
       console.error(e);
     }
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -722,7 +722,6 @@ namespace P.runtime {
     start() {
       this.isRunning = true;
       if (this.interval) return;
-      window.addEventListener('error', this.onError);
       this.baseTime = Date.now();
       this.interval = setInterval(this.step, 1000 / this.framerate);
       if (audioContext) audioContext.resume();
@@ -737,7 +736,6 @@ namespace P.runtime {
         this.baseNow = this.now();
         clearInterval(this.interval);
         this.interval = 0;
-        window.removeEventListener('error', this.onError);
         if (audioContext) audioContext.suspend();
         this.stage.pauseExtensions();
       }


### PR DESCRIPTION
window.onerror is extremely unreliable, especially when other code or browser extensions are running on the page. When phosphorus was written try/catch was (at least perceived to be) very slow, but that's not the case today in Firefox, Chrome, or Safari (https://scratch.mit.edu/projects/310372816/ runs at same speed on git master and this branch)

SB2 and SB3 loading already fed errors into the proper places, so only Runtime#step() has to be updated with new error handling.

Fixes these because we don't use query selectors that look like that: Fixes #596, Fixes #597, Fixes #602, Fixes #603, Fixes #608, Fixes #616, Fixes #620, Fixes #621, Fixes #622, Fixes #623, Fixes #627, Fixes #777, Fixes #782, Fixes #783

Fixes these because that's an error from fetch, an API we don't use: Fixes #524, Fixes #618, Fixes #668, Fixes #708, Fixes #728, Fixes #742, Fixes #747, Fixes #748, Fixes #769, Fixes #776, Fixes #780, Fixes #835, Fixes #836, Fixes #837, Fixes #839