### PR TITLE
Move embed.html ?auto-start option to common

### DIFF
--- a/common.js
+++ b/common.js
@@ -109,6 +109,15 @@ var Common = (function() {
       case 'chhost':
         setPlayerFlag('cloudHistoryHost', value);
         break;
+      case 'auto-start':
+        // "?auto-start" without a value should be interpreted as enabling
+        // auto-start.
+        if (FALSE.includes(value)) {
+          setPlayerOption('autoplayPolicy', 'never');
+        } else {
+          setPlayerOption('autoplayPolicy', 'always');
+        }
+        break;
       // Project ID
       case 'id':
         // projectId is also read from location.hash if not found here.

--- a/embed.html
+++ b/embed.html
@@ -48,13 +48,6 @@
     var hasUI = true;
     Common.parseSearch(function(key, value) {
       switch (key) {
-        case 'auto-start':
-          if (value === 'true') {
-            player.setOptions({ autoplayPolicy: 'always' });
-          } else {
-            player.setOptions({ autoplayPolicy: 'never' });
-          }
-          break;
         case 'light-content':
           if (value === 'true') {
             player.setOptions({ theme: 'dark' });

--- a/index.html
+++ b/index.html
@@ -267,10 +267,13 @@
     console.log('Sprites are exposed in `player.stage.children`');
 
     var initialId = Common.projectId || '';
-    player.setOptions(Common.playerOptions);
     player.setOptions({
+      // Player default is if-audio-playable which doesn't work
+      // well on the website by default. Set this before applying
+      // options from Common since it can be overridden by parameter.
       autoplayPolicy: 'never'
     });
+    player.setOptions(Common.playerOptions);
 
     playerArea.style.height = projectArea.style.height = 'auto';
     var titleAreaHeight = titleArea.offsetHeight;


### PR DESCRIPTION
This was originally part of https://github.com/forkphorus/forkphorus/pull/895 not because it actually made sense organizationally, but rather the project that needed custom stage size also needed autostart in app.html.